### PR TITLE
v3.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# This file is used for Git repositories to specify intentionally untracked files that Git should ignore. 
+# This file is used for Git repositories to specify intentionally untracked files that Git should ignore.
 # If you are not using git, you can delete this file. For more information see: https://git-scm.com/docs/gitignore
 # For useful gitignore templates see: https://github.com/github/gitignore
 
@@ -33,3 +33,6 @@ Thumbs.db
 ehthumbs.db
 [Dd]esktop.ini
 $RECYCLE.BIN/
+
+# Visual Studio Code
+.vscode

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Apex Test Kit is a Salesforce library to help generate massive records for eithe
 
 ### **3.2 Release Notes**
 
-**<a href="#command-api">Command API</a>**: A new `mock()` method is added. If it is used instead of `save()`, a very large fake ID will be generated for the newly created SObjects. This is useful when used with a mock libray together.
+**<a href="#command-api">Command API</a>**: A new `mock()` method is added. If it is used instead of `save()`, very large fake IDs of the SObjectType will be generated for the newly created SObjects. This is useful when used with a mock libray together.
 
 ------
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Apex Test Kit
 
-![](https://img.shields.io/badge/version-3.1.0-brightgreen.svg) ![](https://img.shields.io/badge/build-passing-brightgreen.svg) ![](https://img.shields.io/badge/coverage-95%25-brightgreen.svg)
+![](https://img.shields.io/badge/version-3.2-brightgreen.svg) ![](https://img.shields.io/badge/build-passing-brightgreen.svg) ![](https://img.shields.io/badge/coverage-95%25-brightgreen.svg)
 
 Apex Test Kit is a Salesforce library to help generate massive records for either Apex test classes, or sandboxes. It solves two pain points during record creation:
 
@@ -9,12 +9,9 @@ Apex Test Kit is a Salesforce library to help generate massive records for eithe
 
 ------
 
-### **3.1 Release Notes**
+### **3.2 Release Notes**
 
-3.1 has some `breaking` changes, it shouldn't affect existing methods compilation, since the old APIs are still there. However some changes required to be made to prevent runtime errors.
-
-1. **<a href="#lookup-field-keywords">Lookup Field Keywords</a>** such as `recordType()` and `profile()` can no longer be chained after  `.field()`.
-2. **<a href="#entity-builder-factory">Entity Builder Factory</a>** is a proper name to reflect its responsibility, so ATK.FieldBuilder has been renamed to ATK.EntityBuilder, and has to be used with `.build(entityBuilder)`. ATK.FieldBuilder will be completely removed in the next version 3.2.
+**<a href="#command-api">Command API</a>**: A new `mock()` method is added. If it is used instead of `save()`, a very large fake ID will be generated for the newly created SObjects. This is useful when used with a mock libray together.
 
 ------
 
@@ -69,10 +66,10 @@ To generate the above 2200 records and saving them into Salesforce, it will take
 
 ### Installation
 
-| Environment           | Install Link                                                 | Version   |
-| --------------------- | ------------------------------------------------------------ | --------- |
-| Production, Developer | <a target="_blank" href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t2v000007X3Q7AAK"><img src="docs/images/deploy-button.png"></a> | ver 3.1.0 |
-| Sandbox               | <a target="_blank" href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t2v000007X3Q7AAK"><img src="docs/images/deploy-button.png"></a> | ver 3.1.0 |
+| Environment           | Install Link                                                 | Version |
+| --------------------- | ------------------------------------------------------------ | ------- |
+| Production, Developer | <a target="_blank" href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t2v000007X4XzAAK"><img src="docs/images/deploy-button.png"></a> | ver 3.2 |
+| Sandbox               | <a target="_blank" href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t2v000007X4XzAAK"><img src="docs/images/deploy-button.png"></a> | ver 3.2 |
 
 ### Demos
 
@@ -138,7 +135,17 @@ ATK.prepare(Contact.SObjectType, 40)
     .save();
 ```
 
-## Keywords And APIs
+## Command API
+
+There are three ways to create the sObjects.
+
+| Method API                          | Description                                                  |
+| ----------------------------------- | ------------------------------------------------------------ |
+| SaveResult save()                   | Actual DMLs will be performed to insert/update sObjects into Salesforce. |
+| SaveResult save(Boolean *doInsert*) | If `doInsert` is `false`, no actual DMLs will be performed, just the in-memory generated SObjects will be returned. |
+| SaveResult mock()                   | No actual DMLs will be performed, but extremely large fake IDs of the sObjectType will be assigned to the newly created sObjects. |
+
+## Keywords API
 
 There are only two keyword categories Entity keyword and Field keyword. They are used to solve the two pain points we addressed at the beginning:
 

--- a/apex-test-kit/main/classes/ATK.cls
+++ b/apex-test-kit/main/classes/ATK.cls
@@ -74,7 +74,16 @@ public with sharing class ATK implements Entity, Field {
     }
 
     public SaveResult save(Boolean doInsert) {
-        ATKCore.GENERATOR.generate(this.matrix, doInsert);
+        return generate(doInsert == true, false);
+    }
+
+    public SaveResult mock() {
+        return generate(false, true);
+    }
+
+
+    private SaveResult generate(Boolean doInsert, Boolean doMock) {
+        ATKCore.GENERATOR.generate(this.matrix, doInsert, doMock);
         SaveResult result = new SaveResult();
         for (ATKCore.EntityNode node : matrix.entityNodeCache) {
             if (!result.result.containsKey(node.objectType)) {
@@ -129,12 +138,6 @@ public with sharing class ATK implements Entity, Field {
 
     public Field field(SObjectField field) {
         this.matrix.currEntityNode.addField(field);
-        return sharedCommand;
-    }
-
-    // deprecating on 3.2.0
-    public Entity field(ATK.FieldBuilder builder) {
-        builder.build(sharedCommand, sharedCommand.matrix.currEntityNode.size);
         return sharedCommand;
     }
 
@@ -318,12 +321,12 @@ public with sharing class ATK implements Entity, Field {
         Entity also();
         Entity also(Integer depth);
         Entity build(ATK.EntityBuilder builder);
-        Entity field(ATK.FieldBuilder builder); // deprecating on 3.2.0
         Field field(SObjectField field);
 
         // keywords to end with
         SaveResult save();
         SaveResult save(Boolean doInsert);
+        SaveResult mock();
 
         // keywords to lookup relation
         Entity recordType(String name);
@@ -367,10 +370,6 @@ public with sharing class ATK implements Entity, Field {
 
     public interface EntityBuilder {
         void build(Entity entity, Integer size);
-    }
-
-    // deprecating on 3.2.0
-    public interface FieldBuilder extends EntityBuilder {
     }
     // #endregion
     // ******************

--- a/apex-test-kit/main/classes/ATKCore.cls
+++ b/apex-test-kit/main/classes/ATKCore.cls
@@ -22,6 +22,7 @@ public with sharing class ATKCore {
     public static final Converter CONVERTER = new Converter();
     public static final Generator GENERATOR = new Generator();
     private static final Distributor DISTRIBUTOR = new Distributor();
+    private static final FakeId FAKEID = new FakeId();
 
     // ************************
     // #region Graph Definition
@@ -410,7 +411,7 @@ public with sharing class ATKCore {
             indexes = new Map<Schema.SObjectType, Map<Schema.SObjectField, Integer>>();
         }
 
-        public void generate(EntityNodeMatrix iterator, Boolean doInsert) {
+        public void generate(EntityNodeMatrix iterator, Boolean doInsert, Boolean doMock) {
             iterator.reset();
             while (iterator.hasNext()) {
                 EntityNode entityNode = iterator.next();
@@ -427,6 +428,15 @@ public with sharing class ATKCore {
                 if (entityNode.size > 0) {
                     assignFields(entityNode);
                     assignReference(entityNode, doInsert);
+                }
+
+                if (doMock) {
+                    for (SObject obj : entityNode.objects) {
+                        if (obj.Id == null) {
+                            obj.Id = FAKEID.generate(entityNode.objectType);
+                        }
+                    }
+                    continue;
                 }
 
                 if (!doInsert) {
@@ -581,6 +591,29 @@ public with sharing class ATKCore {
     // ***********************
     // #region Utility Classes
     // ***********************
+    class Indexer {
+        Integer i = 0;
+    }
+
+    public class FakeId {
+        Map<Schema.SObjectType, Indexer> objectIdIndexes { get; set; }
+
+        {
+            objectIdIndexes = new Map<Schema.SObjectType, Indexer>();
+        }
+
+        public String generate(Schema.SObjectType objectType) {
+            if (!objectIdIndexes.containsKey(objectType)) {
+                objectIdIndexes.put(objectType, new Indexer());
+            }
+
+            Indexer idx = objectIdIndexes.get(objectType);
+            idx.i++;
+            return objectType.getDescribe().getKeyPrefix()
+                + '000zzzz' // start from a large Id to avoid confliction during unit test.
+                + String.valueOf(idx.i).leftPad(5, '0');
+        }
+    }
 
     public class StringBuilder {
         List<String> values { get; set; }

--- a/apex-test-kit/main/classes/ATKCoreTest.cls
+++ b/apex-test-kit/main/classes/ATKCoreTest.cls
@@ -410,7 +410,41 @@ public with sharing class ATKCoreTest {
             matrix.add(ATKCore.EntityNodeType.PREPARE, new ATKCore.EntityNode(Account.SObjectType,
                 new List<Account> {new Account(), new Account(), new Account()}), null);
             matrix.add(ATKCore.EntityNodeType.ONE_TO_MANY, new ATKCore.EntityNode(Contact.SObjectType, 3), Contact.AccountId);
-            generator.generate(matrix, false);
+            generator.generate(matrix, false, false);
+        }
+    }
+
+    @IsTest
+    static void test_Generator_Generate_doInsert() {
+        ATKCore.Generator generator = new ATKCore.Generator();
+        {
+            ATKCore.EntityNodeMatrix matrix = new ATKCore.EntityNodeMatrix();
+            matrix.add(ATKCore.EntityNodeType.PREPARE, new ATKCore.EntityNode(Account.SObjectType,
+                new List<Account> {new Account(), new Account(), new Account()}), null);
+            matrix.add(ATKCore.EntityNodeType.ONE_TO_MANY, new ATKCore.EntityNode(Contact.SObjectType, 3), Contact.AccountId);
+            try {
+                generator.generate(matrix, true, false);
+            } catch(Exception ex) {}
+        }
+    }
+
+    @IsTest
+    static void test_Generator_Generate_doMock() {
+        ATKCore.Generator generator = new ATKCore.Generator();
+        {
+            ATKCore.EntityNodeMatrix matrix = new ATKCore.EntityNodeMatrix();
+            matrix.add(ATKCore.EntityNodeType.PREPARE, new ATKCore.EntityNode(Account.SObjectType,
+                new List<Account> {new Account(), new Account(), new Account()}), null);
+            matrix.add(ATKCore.EntityNodeType.ONE_TO_MANY, new ATKCore.EntityNode(Contact.SObjectType, 3), Contact.AccountId);
+            generator.generate(matrix, false, true);
+
+            System.assertEquals(2, matrix.entityNodeCache.size());
+            for (ATKCore.EntityNode node : matrix.entityNodeCache) {
+                System.assert(node.objects.size() > 0);
+                for (SObject obj : node.objects) {
+                    System.assertNotEquals(null, obj.Id);
+                }
+            }
         }
     }
 

--- a/apex-test-kit/main/classes/ATKTest.cls
+++ b/apex-test-kit/main/classes/ATKTest.cls
@@ -32,10 +32,10 @@ public with sharing class ATKTest {
             Account acc = (Account)result.get(Account.SObjectType)[i];
             Contact contact1 = (Contact)result.get(Contact.SObjectType)[i * 2];
             Contact contact2 = (Contact)result.get(Contact.SObjectType)[i * 2 + 1];
-            Case case1 = (Case)result.get(Case.SObjectType)[i * 2];
-            Case case2 = (Case)result.get(Case.SObjectType)[i * 2 + 1];
-            Case case3 = (Case)result.get(Case.SObjectType)[i * 2];
-            Case case4 = (Case)result.get(Case.SObjectType)[i * 2 + 1];
+            Case case1 = (Case)result.get(Case.SObjectType)[i * 4];
+            Case case2 = (Case)result.get(Case.SObjectType)[i * 4 + 1];
+            Case case3 = (Case)result.get(Case.SObjectType)[i * 4 + 2];
+            Case case4 = (Case)result.get(Case.SObjectType)[i * 4 + 3];
 
             System.assertEquals(acc, contact1.Account);
             System.assertEquals(acc, contact2.Account);
@@ -47,6 +47,38 @@ public with sharing class ATKTest {
             System.assertEquals(contact1, case2.Contact);
             System.assertEquals(contact2, case3.Contact);
             System.assertEquals(contact2, case4.Contact);
+        }
+    }
+
+    @IsTest
+    static void test_OneToMany_mock() {
+        ATK.SaveResult result = ATK.prepare(Account.SObjectType, 10)
+            .withChildren(Case.SObjectType, Case.AccountId, 40)
+            .also()
+            .withChildren(Contact.SObjectType, Contact.AccountId, 20)
+                // in order to test this method
+                .withChildren(Case.SObjectType, Case.ContactId)
+            .save(false);
+
+        for (Integer i = 0; i < 10; i++) {
+            Account acc = (Account)result.get(Account.SObjectType)[i];
+            Contact contact1 = (Contact)result.get(Contact.SObjectType)[i * 2];
+            Contact contact2 = (Contact)result.get(Contact.SObjectType)[i * 2 + 1];
+            Case case1 = (Case)result.get(Case.SObjectType)[i * 4];
+            Case case2 = (Case)result.get(Case.SObjectType)[i * 4 + 1];
+            Case case3 = (Case)result.get(Case.SObjectType)[i * 4 + 2];
+            Case case4 = (Case)result.get(Case.SObjectType)[i * 4 + 3];
+
+            System.assertEquals(acc.Id, contact1.Account.Id);
+            System.assertEquals(acc.Id, contact2.Account.Id);
+            System.assertEquals(acc.Id, case1.Account.Id);
+            System.assertEquals(acc.Id, case2.Account.Id);
+            System.assertEquals(acc.Id, case3.Account.Id);
+            System.assertEquals(acc.Id, case4.Account.Id);
+            System.assertEquals(contact1.Id, case1.Contact.Id);
+            System.assertEquals(contact1.Id, case2.Contact.Id);
+            System.assertEquals(contact2.Id, case3.Contact.Id);
+            System.assertEquals(contact2.Id, case4.Contact.Id);
         }
     }
 
@@ -125,14 +157,15 @@ public with sharing class ATKTest {
                     .withParents(Account.SObjectType, Case.AccountId)
             .save(false);
 
+
         for (Integer i = 0; i < 10; i++) {
             Account acc = (Account)result.get(Account.SObjectType)[i];
             Contact contact1 = (Contact)result.get(Contact.SObjectType)[i * 2];
             Contact contact2 = (Contact)result.get(Contact.SObjectType)[i * 2 + 1];
-            Case case1 = (Case)result.get(Case.SObjectType)[i * 2];
-            Case case2 = (Case)result.get(Case.SObjectType)[i * 2 + 1];
-            Case case3 = (Case)result.get(Case.SObjectType)[i * 2];
-            Case case4 = (Case)result.get(Case.SObjectType)[i * 2 + 1];
+            Case case1 = (Case)result.get(Case.SObjectType)[i * 4];
+            Case case2 = (Case)result.get(Case.SObjectType)[i * 4 + 1];
+            Case case3 = (Case)result.get(Case.SObjectType)[i * 4 + 2];
+            Case case4 = (Case)result.get(Case.SObjectType)[i * 4 + 3];
 
             System.assertEquals(acc, contact1.Account);
             System.assertEquals(acc, contact2.Account);
@@ -148,9 +181,41 @@ public with sharing class ATKTest {
     }
 
     @IsTest
+    static void test_ManyToOne_Mock() {
+        ATK.SaveResult result = ATK.prepare(Account.SObjectType, 10)
+            .withChildren(Contact.SObjectType, Contact.AccountId, 20)
+                .withChildren(Case.SObjectType, Case.ContactId, 40)
+                    // in order to test this method
+                    .withParents(Account.SObjectType, Case.AccountId)
+            .mock();
+
+
+        for (Integer i = 0; i < 10; i++) {
+            Account acc = (Account)result.get(Account.SObjectType)[i];
+            Contact contact1 = (Contact)result.get(Contact.SObjectType)[i * 2];
+            Contact contact2 = (Contact)result.get(Contact.SObjectType)[i * 2 + 1];
+            Case case1 = (Case)result.get(Case.SObjectType)[i * 4];
+            Case case2 = (Case)result.get(Case.SObjectType)[i * 4 + 1];
+            Case case3 = (Case)result.get(Case.SObjectType)[i * 4 + 2];
+            Case case4 = (Case)result.get(Case.SObjectType)[i * 4 + 3];
+
+            System.assertEquals(acc.Id, contact1.Account.Id);
+            System.assertEquals(acc.Id, contact2.Account.Id);
+            System.assertEquals(acc.Id, case1.Account.Id);
+            System.assertEquals(acc.Id, case2.Account.Id);
+            System.assertEquals(acc.Id, case3.Account.Id);
+            System.assertEquals(acc.Id, case4.Account.Id);
+            System.assertEquals(contact1.Id, case1.Contact.Id);
+            System.assertEquals(contact1.Id, case2.Contact.Id);
+            System.assertEquals(contact2.Id, case3.Contact.Id);
+            System.assertEquals(contact2.Id, case4.Contact.Id);
+        }
+    }
+
+    @IsTest
     static void test_ManyToOne_Size() {
         ATK.SaveResult result = ATK.prepare(Contact.SObjectType, 20)
-            .withParents(Account.SObjectType, Contact.AccountId, 20)
+            .withParents(Account.SObjectType, Contact.AccountId, 10)
             .save(false);
 
         for (Integer i = 0; i < 10; i++) {
@@ -186,8 +251,8 @@ public with sharing class ATKTest {
             contacts.add(new Contact());
         }
 
-        ATK.SaveResult result = ATK.prepare(Contact.SObjectType, 20)
-            .withParents(Account.SObjectType, Contact.AccountId, 20)
+        ATK.SaveResult result = ATK.prepare(Contact.SObjectType, contacts)
+            .withParents(Account.SObjectType, Contact.AccountId, accounts)
             .save(false);
 
         for (Integer i = 0; i < 10; i++) {
@@ -257,7 +322,7 @@ public with sharing class ATKTest {
     static void test_Fields() {
         ATK.prepare(Account.SObjectType, 0)
             .recordType('==Fake Record Type==')
-            .field(new AccountFieldBuilder())
+            .build(new AccountEntityBuilder())
             .field(Account.Name).index('Name-{0000}')
             .field(Account.Name).repeat('A')
             .field(Account.Name).repeat('A', 'B')
@@ -282,7 +347,7 @@ public with sharing class ATKTest {
             .permissionSet(new List<String> {'==Fake Permission Set 1==', '==Fake Permission Set 2=='});
     }
 
-    class AccountFieldBuilder implements ATK.FieldBuilder {
+    class AccountEntityBuilder implements ATK.EntityBuilder {
         public void build(ATK.Entity accountEneity, Integer size) {
         }
     }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -3,8 +3,8 @@
         {
             "path": "apex-test-kit",
             "package": "ApexTestKit",
-            "versionName": "ver 3.1.0",
-            "versionNumber": "3.1.0.NEXT",
+            "versionName": "ver 3.2.0",
+            "versionNumber": "3.2.0.NEXT",
             "default": true
         }
     ],
@@ -16,6 +16,7 @@
         "ApexTestKit@3.0.0-2": "04t2v000007X2zHAAS",
         "ApexTestKit@3.0.1-1": "04t2v000007X3BAAA0",
         "ApexTestKit@3.0.2-1": "04t2v000007X3LqAAK",
-        "ApexTestKit@3.1.0-1": "04t2v000007X3Q7AAK"
+        "ApexTestKit@3.1.0-1": "04t2v000007X3Q7AAK",
+        "ApexTestKit@3.2.0-1": "04t2v000007X4XzAAK"
     }
 }


### PR DESCRIPTION
A new `mock()` method is added. If it is used instead of `save()`, very large fake IDs of the SObjectType will be generated for the newly created SObjects. This is useful when used with a mock libray together.