### PR TITLE
v3.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,31 @@
 # Apex Test Kit
 
-![](https://img.shields.io/badge/version-3.3%20beta-orange.svg) ![](https://img.shields.io/badge/build-passing-brightgreen.svg) ![](https://img.shields.io/badge/coverage-95%25-brightgreen.svg)
+![](https://img.shields.io/badge/version-3.3.1-brightgreen.svg) ![](https://img.shields.io/badge/build-passing-brightgreen.svg) ![](https://img.shields.io/badge/coverage-95%25-brightgreen.svg)
 
 Apex Test Kit can help generate massive records for Apex test classes. It solves two pain points during record creation:
 
 1. Establish arbitrary levels of many-to-one, one-to-many relationships.
 2. Generate field values based on simple rules automatically.
 
+| Environment           | Installation Link                                            | Version |
+| --------------------- | ------------------------------------------------------------ | ------- |
+| Production, Developer | <a target="_blank" href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t2v000007GQuwAAG"><img src="docs/images/deploy-button.png"></a> | ver 3.3.1 |
+| Sandbox               | <a target="_blank" href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t2v000007GQuwAAG"><img src="docs/images/deploy-button.png"></a> | ver 3.3.1 |
+
 ------
 
-### **3.3 Beta Release Notes**
+### **v3.3 Release Notes**
 
 **[Lookup Field Keywords](#lookup-field-keywords)** has some **breaking changes**:
 
-- `recordType()` keyword will only support record type developer name, and become *case sensitive*.
+- `recordType()` will only support developer name as param, and become *case sensitive*.
 
 **[Command API](#command-api)**:
 
 - `mock()` now supports assigning read-only fields, such as *formula fields*, *rollup summary fields*, and *system fields*. For example `.field(Account.CreatedDate).repeat(Datetime.newInstance(2020, 1, 1))`.
-- Fixed a bug for v3.2 when fake Ids are assigned during `mock()`, the master-detail relationships are not updatable. Now update the master-deteil relationship first, then assign fake Ids to the records.
+- Fix:  Fake Id assignments of sObjects during `mock()`  blocking some relationships to be updated.
 
-**[Performance](#performance)** adds **benchmark** section to give a feel how fast it is to use `mock()` instead of `save()`.
+**[Performance](#performance)** adds **benchmark** to give a feel how fast it is to use `mock()` compared with `save()`.
 
 
 Happy hacking!
@@ -31,7 +36,6 @@ Happy hacking!
 
 - [Introduction](#introduction)
   - [Performance](#performance)
-  - [Installation](#installation)
   - [Demos](#demos)
 - [Relationship](#relationship)
   - [One to Many](#one-to-many)
@@ -98,19 +102,17 @@ ATK.SaveResult result = ATK.prepare(Account.SObjectType, 200)
 
 To `.save()` the above 2200 records, it will take ~3000 CPU time. That's already 1/3 of the Maximum CPU time. However, if we use `.mock()` to just create them in the memory, it will take ~700 CPU time.
 
-**Benchmark**: Insert 1000 accounts without duplicate rules, process builders, and triggers etc. The scripts used to perform benchmark testing are documented under `scripts/apex/benchmark.apex`.
+#### Benchmark
 
-| 1000 * Account | Database.insert() | ATK Save() | ATK Mock() | Save/Mock |
-| -------------- | ----------------- | ---------- | ---------- | --------- |
-| CPU Time       | 0                 | 2024       | 401        | ~5x       |
-| Real Time (ms) | 6803              | 6430       | 526        | ~12x      |
+The scripts used to perform benchmark testing are documented under `scripts/apex/benchmark.apex`. All tests will insert 1000 accounts under the following conditions:
 
-### Installation
+1. No duplicate rules, process builders, and triggers etc.
+2. ApexCode debug level is set to DEBUG.
 
-| Environment           | Install Link                                                 | Version |
-| --------------------- | ------------------------------------------------------------ | ------- |
-| Production, Developer | <a target="_blank" href="https://login.salesforce.com/packaging/installPackage.apexp?p0=04t2v000007X4qeAAC"><img src="docs/images/deploy-button.png"></a> | ver 3.2.1 |
-| Sandbox               | <a target="_blank" href="https://test.salesforce.com/packaging/installPackage.apexp?p0=04t2v000007X4qeAAC"><img src="docs/images/deploy-button.png"></a> | ver 3.2.1 |
+| 1000 * Account | Database.insert | ATK Save | ATK Mock | ATK Save/Mock |
+| -------------- | --------------- | -------- | -------- | ------------- |
+| CPU Time       | 0               | 2024     | 401      | ~5x           |
+| Real Time (ms) | 6803            | 6430     | 526      | ~12x          |
 
 ### Demos
 

--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ ATK.SaveResult result = ATK.prepare(Account.SObjectType, 200)
 
 ### Performance
 
-To `.save()` the above 2200 records, it will take ~3000 CPU time. That's already 1/3 of the Maximum CPU time. However, if we use `.mock()` without saving them, and just create them in the memory, it will take ~700 CPU time.
+To `.save()` the above 2200 records, it will take ~3000 CPU time. That's already 1/3 of the Maximum CPU time. However, if we use `.mock()` to just create them in the memory, it will take ~700 CPU time.
 
-**Benchmark**: Insert 1000 accounts without duplicate rules, process builders, and triggers etc. The scripts used for 
+**Benchmark**: Insert 1000 accounts without duplicate rules, process builders, and triggers etc. The scripts used to perform benchmark testing are documented under `scripts/apex/benchmark.apex`.
 
 | 1000 * Account | Database.insert() | ATK Save() | ATK Mock() | Save/Mock |
 | -------------- | ----------------- | ---------- | ---------- | --------- |
@@ -288,20 +288,20 @@ These are field keywords in nature, but don't need to be chained after `.field(S
 ```java
 ATK.prepare(User.SObjectType, 10)
     .profile('Chatter Free User')      // must be applied to User SObject
-    .permissionSet('Survey Creator');  // must be applied to User SObject
+    .permissionSet('Survey_Creator');  // must be applied to User SObject
 
 ATK.prepare(Account.SObjectType, 10)
-    .recordType('Business Account');
+    .recordType('Business_Account');
 ```
 
-| Keyword API                                                  | Description                                                  |
-| ------------------------------------------------------------ | ------------------------------------------------------------ |
-| recordType(String *name*)                                    | Assign record type ID by developer name and case sensitive.  |
-| profile(String *name*)                                       | Assign profile ID by profile name.                           |
-| permissionSet(String *name*)                                 | Assign the permission set to users by its developer name or label. |
-| permissionSet(String name1, String *name2*)                  | Assign all the permission sets to users by developer name or label. |
-| permissionSet(String *name1*, String *name2*, String *name3*) | Assign all the permission sets to users by developer name or label. |
-| permissionSet(List\<String\> *names*)                        | Assign all the permission sets to users by developer name or label. |
+| Keyword API                                                  | Description                                                 |
+| ------------------------------------------------------------ | ----------------------------------------------------------- |
+| recordType(String *name*)                                    | Assign record type ID by developer name and case sensitive. |
+| profile(String *name*)                                       | Assign profile ID by profile name.                          |
+| permissionSet(String *name*)                                 | Assign the permission set to users by developer name.       |
+| permissionSet(String name1, String *name2*)                  | Assign all the permission sets to users by developer names. |
+| permissionSet(String *name1*, String *name2*, String *name3*) | Assign all the permission sets to users by developer names. |
+| permissionSet(List\<String\> *names*)                        | Assign all the permission sets to users by developer names. |
 
 ### Arithmetic Field Keywords
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Apex Test Kit
 
-![](https://img.shields.io/badge/version-3.3 beta-orange.svg) ![](https://img.shields.io/badge/build-passing-brightgreen.svg) ![](https://img.shields.io/badge/coverage-95%25-brightgreen.svg)
+![](https://img.shields.io/badge/version-3.3%20beta-orange.svg) ![](https://img.shields.io/badge/build-passing-brightgreen.svg) ![](https://img.shields.io/badge/coverage-95%25-brightgreen.svg)
 
 Apex Test Kit can help generate massive records for Apex test classes. It solves two pain points during record creation:
 
@@ -11,15 +11,16 @@ Apex Test Kit can help generate massive records for Apex test classes. It solves
 
 ### **3.3 Beta Release Notes**
 
-**<a href="#lookup-field-keywords">Lookup Field Keywords</a>** has some **breaking changes**:
+**[Lookup Field Keywords](#lookup-field-keywords)** has some **breaking changes**:
 
 - `recordType()` keyword will only support record type developer name, and become *case sensitive*.
 
-**<a href="#command-api">Command API</a>** `mock()` now supports:
+**[Command API](#command-api)**:
 
-- Generate read-only fields, such as *formula fields*, *rollup summary fields*, and *system fields*. For example `.field(Account.CreatedDate).repeat(Datetime.newInstance(2020, 1, 1))`
-- Generate fake sObject Ids.
-- Fixed a bug when Id is assigned, the record master-detail relationship is not updatable.
+- `mock()` now supports assigning read-only fields, such as *formula fields*, *rollup summary fields*, and *system fields*. For example `.field(Account.CreatedDate).repeat(Datetime.newInstance(2020, 1, 1))`.
+- Fixed a bug for v3.2 when fake Ids are assigned during `mock()`, the master-detail relationships are not updatable. Now update the master-deteil relationship first, then assign fake Ids to the records.
+
+**[Performance](#performance)** adds **benchmark** section to give a feel how fast it is to use `mock()` instead of `save()`.
 
 
 Happy hacking!
@@ -38,8 +39,8 @@ Happy hacking!
   - [Many to Many](#many-to-many)
 - [Command API](#command-api)
 - [Entity Keywords](#entity-keywords)
-  - [Entity Create Keywords](#entity-create-keywords)
-  - [Entity Update Keywords](#entity-update-keywords)
+  - [Entity Creation Keywords](#entity-creation-keywords)
+  - [Entity Updating Keywords](#entity-updating-keywords)
   - [Entity Reference Keywords](#entity-reference-keywords)
 - [Field Keywords](#field-keywords)
   - [Basic Field Keywords](#basic-field-keywords)
@@ -181,9 +182,9 @@ There are three ways to create the sObjects.
 
 | Method API                          | Description                                                  |
 | ----------------------------------- | ------------------------------------------------------------ |
-| SaveResult save()                   | Actual DMLs will be performed to insert/update sObjects into Salesforce. |
+| `SaveResult save()                  | Actual DMLs will be performed to insert/update sObjects into Salesforce. |
 | SaveResult save(Boolean *doInsert*) | If `doInsert` is `false`, no actual DMLs will be performed, just the in-memory generated SObjects will be returned. |
-| SaveResult mock()                   | 1. No actual DMLs will be performed, and extremely large fake IDs of the sObjectType will be assigned to sObjects.<br />2. Support assigning values to read-only fields, such as *formula fields*, *rollup summary fields*, and *system fields*, when `mock()` is called instead of `save()` |
+| SaveResult *mock()*                 | 1. No actual DMLs will be performed, and extremely large fake IDs of the sObjectType will be assigned to sObjects.<br />2. Support assigning values to read-only fields, such as *formula fields*, *rollup summary fields*, and *system fields*.<br />3. Can only work with [Entity Creation Keywords](#entity-creation-keywords). |
 
 ## Entity Keywords
 

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ These keywords will increase/decrease the init values by the provided step value
 
 ## Entity Builder Factory
 
-It is recommended to keep how the sObject relationship is established in the test class. Because they are less subject to change, and clearer to the developers. In order to increase the reusability, let's introduce the Entity Builder Factory:
+In order to increase the reusability of ATK, we can abstract the field keywords into an Entity Builder. Here is how it can be used in a test class:
 
 ```java
 @IsTest
@@ -339,7 +339,7 @@ public with sharing class CampaignServiceTest {
 }
 ```
 
-A field builder factory example:
+And let's introduce the Entity Builder Factory:
 
 ```java
 @IsTest
@@ -347,25 +347,25 @@ public with sharing class EntityBuilderFactory {
     public static CampaignEntityBuilder campaignBuilder = new CampaignEntityBuilder();
     public static LeadEntityBuilder leadBuilder = new LeadEntityBuilder();
 
-    // Inner class implements ATK.FieldBuilder
+    // Inner class implements ATK.EntityBuilder
     public class CampaignEntityBuilder implements ATK.EntityBuilder {
         public void build(ATK.Entity campaignEntity, Integer size) {
             campaignEntity
                 .field(Campaign.Type).repeat('Partners')
                 .field(Campaign.Name).index('Name-{0000}')
                 .field(Campaign.StartDate).repeat(Date.newInstance(2020, 1, 1))
-                .field(Campaign.EndDate).repeat(Date.newInstance(2020, 1, 1).addMonths(1))
+                .field(Campaign.EndDate).repeat(Date.newInstance(2020, 1, 1));
         }
     }
 
-    // Inner class implements ATK.FieldBuilder
+    // Inner class implements ATK.EntityBuilder
     public class LeadEntityBuilder implements ATK.EntityBuilder {
         public void build(ATK.Entity leadEntity, Integer size) {
             leadEntity
                 .field(Lead.Company).index('Name-{0000}')
                 .field(Lead.LastName).index('Name-{0000}')
                 .field(Lead.Email).index('test.user+{0000}@email.com')
-                .field(Lead.MobilePhone).index('+86 186 7777 {0000}')
+                .field(Lead.MobilePhone).index('+86 186 7777 {0000}');
         }
     }
 }

--- a/apex-test-kit/main/classes/ATK.cls
+++ b/apex-test-kit/main/classes/ATK.cls
@@ -187,12 +187,15 @@ public with sharing class ATK implements Entity, Field {
 
     public Entity permissionSet(List<String> names) {
         if (User.SObjectType == sharedCommand.matrix.currEntityNode.objectType) {
-            sharedCommand.withChildren(
-                PermissionSetAssignment.SObjectType,
-                PermissionSetAssignment.AssigneeId,
-                sharedCommand.matrix.currEntityNode.size * names.size())
-                .field(PermissionSetAssignment.PermissionSetId).repeat(ATKCore.PERMISSION_SETS.getIds(names))
-                .also();
+            List<Id> permissionSetIds = ATKCore.PERMISSION_SETS.getIds(names);
+            if (permissionSetIds.size() > 0) {
+                sharedCommand.withChildren(
+                    PermissionSetAssignment.SObjectType,
+                    PermissionSetAssignment.AssigneeId,
+                    sharedCommand.matrix.currEntityNode.size * permissionSetIds.size())
+                    .field(PermissionSetAssignment.PermissionSetId).repeat(permissionSetIds)
+                    .also();
+            }
         }
         return sharedCommand;
     }

--- a/apex-test-kit/main/classes/ATK.cls
+++ b/apex-test-kit/main/classes/ATK.cls
@@ -158,7 +158,7 @@ public with sharing class ATK implements Entity, Field {
             .fields.getMap().get('RecordTypeId');
         if (recordTypeIdField != null) {
             sharedCommand.field(recordTypeIdField).repeat(ATKCore.RECORD_TYPES
-                .getId(this.matrix.currEntityNode.objectType, name));
+                .getId(this.matrix.currEntityNode.dsr, name));
         }
         return sharedCommand;
     }
@@ -199,7 +199,6 @@ public with sharing class ATK implements Entity, Field {
 
     public Entity index(String format) {
         this.matrix.currEntityNode.currEntityField.indexFormat = format;
-        this.matrix.currEntityNode.currEntityField.uniqueIndex = true;
         return sharedCommand;
     }
 

--- a/apex-test-kit/main/classes/ATK.cls-meta.xml
+++ b/apex-test-kit/main/classes/ATK.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>45.0</apiVersion>
+    <apiVersion>49.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/apex-test-kit/main/classes/ATKCore.cls
+++ b/apex-test-kit/main/classes/ATKCore.cls
@@ -22,7 +22,9 @@ public with sharing class ATKCore {
     public static final Converter CONVERTER = new Converter();
     public static final Generator GENERATOR = new Generator();
     private static final Distributor DISTRIBUTOR = new Distributor();
-    private static final FakeId FAKEID = new FakeId();
+    public static final FakeId FAKEID = new FakeId();
+    @TestVisible
+    private static Integer batchSize = 200;
 
     // ************************
     // #region SObject Creation
@@ -40,9 +42,19 @@ public with sharing class ATKCore {
             while (iterator.hasNext()) {
                 EntityNode entityNode = iterator.next();
                 Boolean needUpsert = true;
-                if (entityNode.objects.size() == 0) {
+                List<SObject> objects = entityNode.objects;
+                if (objects.size() == 0) {
                     needUpsert = false;
-                    entityNode.objects.addAll(createObjects(entityNode, doMock));
+                    objects.addAll(createObjects(entityNode, doMock));
+                }
+
+                if (doMock) {
+                    List<Id> ids = FAKEID.generate(entityNode.objectType, objects.size());
+                    for (Integer i = 0; i < objects.size(); i++) {
+                        if (objects[i].Id == null) {
+                            objects[i].Id = ids[i];
+                        }
+                    }
                 }
 
                 if (entityNode.size > 0) {
@@ -80,20 +92,11 @@ public with sharing class ATKCore {
         public List<SObject> createObjects(EntityNode entityNode, Boolean doMock) {
             List<SObject> objects = new List<SObject>();
             if (doMock && entityNode.readonlyFields.size() > 0) {
-                objects = buildSObjectListByBatch(entityNode, 200);
+                objects = buildSObjectListByBatch(entityNode, batchSize);
             } else {
                 Schema.SObjectType objectType = entityNode.objectType;
                 for (Integer i = 0; i < entityNode.size; ++i) {
                     objects.add(objectType.newSObject());
-                }
-            }
-
-            if (doMock) {
-                List<Id> ids = FAKEID.generate(entityNode.objectType, objects.size());
-                for (Integer i = 0; i < objects.size(); i++) {
-                    if (objects[i].Id == null) {
-                        objects[i].Id = ids[i];
-                    }
                 }
             }
             return objects;
@@ -104,6 +107,7 @@ public with sharing class ATKCore {
             for (Integer i = 0; i * numberPerBatch < entityNode.size; i++) {
                 Integer endIndex = Math.min((i + 1) * numberPerBatch, entityNode.size);
                 String objectArrayJSON = buildSObjectArrayJSON(entityNode, i * numberPerBatch, endIndex);
+                System.debug(objectArrayJSON);
                 objects.addAll((List<SObject>)JSON.deserialize(objectArrayJSON, List<SObject>.class));
             }
             return objects;
@@ -142,7 +146,7 @@ public with sharing class ATKCore {
             SObjectType objectType, List<EntityField> entityFields, Integer startIndex, Integer endIndex) {
 
             List<Map<String, String>> fieldMaps = new List<Map<String, String>>();
-            for (Integer i = startIndex; i < endIndex; ++i) {
+            for (Integer i = 0; i < endIndex - startIndex; ++i) {
                 fieldMaps.add(new Map<String, String>());
             }
 
@@ -152,37 +156,37 @@ public with sharing class ATKCore {
                         when DATE {
                             Date init = Converter.toDate(entityField.initValue);
                             Integer step = Converter.toInteger(entityField.stepVAlue);
-                            for (Integer i = startIndex; i < endIndex; ++i) {
-                                fieldMaps[0].put(entityField.dfr.getName(), String.valueOf(entityField.getValue(init, step, i)));
+                            for (Integer i = 0; i < endIndex - startIndex; ++i) {
+                                fieldMaps[i].put(entityField.dfr.getName(), CONVERTER.toString(entityField.getValue(init, step, i + startIndex)));
                             }
                         }
                         when DATETIME {
                             Datetime init = Converter.toDatetime(entityField.initValue);
                             Integer step = Converter.toInteger(entityField.stepVAlue);
-                            for (Integer i = startIndex; i < endIndex; ++i) {
-                                fieldMaps[0].put(entityField.dfr.getName(), String.valueOf(entityField.getValue(init, step, i)));
+                            for (Integer i = 0; i < endIndex - startIndex; ++i) {
+                                fieldMaps[i].put(entityField.dfr.getName(), CONVERTER.toString(entityField.getValue(init, step, i + startIndex)));
                             }
                         }
                         when TIME {
                             Time init = Converter.toTime(entityField.initValue);
                             Integer step = Converter.toInteger(entityField.stepVAlue);
-                            for (Integer i = startIndex; i < endIndex; ++i) {
-                                fieldMaps[0].put(entityField.dfr.getName(), String.valueOf(entityField.getValue(init, step, i)));
+                            for (Integer i = 0; i < endIndex - startIndex; ++i) {
+                                fieldMaps[i].put(entityField.dfr.getName(), String.valueOf(entityField.getValue(init, step, i + startIndex)));
                             }
                         }
                         when DOUBLE, INTEGER, PERCENT, CURRENCY {
                             Decimal init = Converter.toDecimal(entityField.initValue);
                             Decimal step = Converter.toDecimal(entityField.stepVAlue);
-                            for (Integer i = startIndex; i < endIndex; ++i) {
-                                fieldMaps[0].put(entityField.dfr.getName(), String.valueOf(entityField.getValue(init, step, i)));
+                            for (Integer i = 0; i < endIndex - startIndex; ++i) {
+                                fieldMaps[i].put(entityField.dfr.getName(), String.valueOf(entityField.getValue(init, step, i + startIndex)));
                             }
                         }
                     }
                 } else {
                     Integer start = reserveIndex(objectType, entityField.field, endIndex - startIndex);
-                    for (Integer i = startIndex; i < endIndex; ++i) {
+                    for (Integer i = 0; i < endIndex - startIndex; ++i) {
                         Object value = entityField.getValue(i + start);
-                        fieldMaps[0].put(entityField.dfr.getName(), String.valueOf(value));
+                        fieldMaps[i].put(entityField.dfr.getName(), CONVERTER.toString(value));
                     }
                 }
             }
@@ -267,6 +271,9 @@ public with sharing class ATKCore {
                     for (List<SObject> pair : DISTRIBUTOR.distribute(childObjectList, parentObjectList)) {
                         // pair[0] = child
                         // pair[1] = parent
+                        System.debug(referenceField.getDescribe().isCreateable());
+                        System.debug(referenceField.getDescribe().isUpdateable());
+                        System.debug(pair[1].Id);
                         pair[0].put(referenceField, pair[1].Id);
                         pair[0].putSObject(relationshipName, pair[1]);
                     }
@@ -521,7 +528,7 @@ public with sharing class ATKCore {
             } else {
                 entityField = new EntityField(field);
                 this.fieldMap.put(field, entityField);
-                if (entityField.dfr.isCalculated()) {
+                if (!entityField.dfr.isCreateable()) {
                     this.readonlyFields.add(entityField);
                 } else {
                     this.writableFields.add(entityField);
@@ -698,41 +705,6 @@ public with sharing class ATKCore {
         Integer i = 0;
     }
 
-    public class FakeId {
-        Map<Schema.SObjectType, Indexer> objectIdIndexes { get; set; }
-
-        {
-            objectIdIndexes = new Map<Schema.SObjectType, Indexer>();
-        }
-
-        public String generate(Schema.SObjectType objectType) {
-            if (!objectIdIndexes.containsKey(objectType)) {
-                objectIdIndexes.put(objectType, new Indexer());
-            }
-
-            Indexer idx = objectIdIndexes.get(objectType);
-            idx.i++;
-            return objectType.getDescribe().getKeyPrefix()
-                + '000zzzz' // start from a large Id to avoid confliction during unit test.
-                + String.valueOf(idx.i).leftPad(5, '0');
-        }
-
-        public List<String> generate(Schema.SObjectType objectType, Integer size) {
-            List<String> ids = new List<String>();
-            if (!objectIdIndexes.containsKey(objectType)) {
-                objectIdIndexes.put(objectType, new Indexer());
-            }
-
-            Indexer idx = objectIdIndexes.get(objectType);
-            // start from a large Id to avoid confliction during unit test.
-            String prefix = objectType.getDescribe().getKeyPrefix() + '000zzzz';
-            for (Integer i = 0; i < size; i++) {
-                ids.add(prefix + String.valueOf(++idx.i).leftPad(5, '0'));
-            }
-            return ids;
-        }
-    }
-
     public class StringBuilder {
         List<String> values { get; set; }
 
@@ -863,6 +835,10 @@ public with sharing class ATKCore {
                 return null;
             } else if (input instanceof String) {
                 return (String)input;
+            } else if (input instanceof Date) {
+                return ((Datetime)input).format('yyyy-MM-dd');
+            } else if (input instanceof Datetime) {
+                return ((Datetime)input).formatGMT('yyyy-MM-dd\'T\'HH:mm:ss.SSS\'Z\'');
             } else {
                 return String.valueOf(input);
             }
@@ -938,7 +914,10 @@ public with sharing class ATKCore {
         public List<Id> getIds(List<String> names) {
             List<Id> ids = new List<Id>();
             for (String name : names) {
-                ids.add(this.getId(name));
+                Id id = this.getId(name);
+                if (id != null) {
+                    ids.add(id);
+                }
             }
             return ids;
         }
@@ -971,6 +950,34 @@ public with sharing class ATKCore {
                 return recordTypeInfo.getRecordTypeId();
             }
             return null;
+        }
+    }
+
+    public class FakeId {
+        Map<Schema.SObjectType, Indexer> objectIdIndexes { get; set; }
+
+        {
+            objectIdIndexes = new Map<Schema.SObjectType, Indexer>();
+        }
+
+        public String get(Schema.SObjectType objectType, Integer i) {
+            return objectType.getDescribe().getKeyPrefix()
+                + '000zzzz'
+                + String.valueOf(i).leftPad(5, '0');
+        }
+
+        public List<String> generate(Schema.SObjectType objectType, Integer size) {
+            List<String> ids = new List<String>();
+            if (!objectIdIndexes.containsKey(objectType)) {
+                objectIdIndexes.put(objectType, new Indexer());
+            }
+
+            Indexer idx = objectIdIndexes.get(objectType);
+            String prefix = objectType.getDescribe().getKeyPrefix() + '000zzzz';
+            for (Integer i = 0; i < size; i++) {
+                ids.add(prefix + String.valueOf(++idx.i).leftPad(5, '0'));
+            }
+            return ids;
         }
     }
 

--- a/apex-test-kit/main/classes/ATKCore.cls
+++ b/apex-test-kit/main/classes/ATKCore.cls
@@ -25,6 +25,294 @@ public with sharing class ATKCore {
     private static final FakeId FAKEID = new FakeId();
 
     // ************************
+    // #region SObject Creation
+    // ************************
+
+    public class Generator {
+        public Map<Schema.SObjectType, Map<Schema.SObjectField, Integer>> indexes { get; set; }
+
+        {
+            indexes = new Map<Schema.SObjectType, Map<Schema.SObjectField, Integer>>();
+        }
+
+        public void generate(EntityNodeMatrix iterator, Boolean doInsert, Boolean doMock) {
+            iterator.reset();
+            while (iterator.hasNext()) {
+                EntityNode entityNode = iterator.next();
+                Boolean needUpsert = true;
+                if (entityNode.objects.size() == 0) {
+                    needUpsert = false;
+                    entityNode.objects.addAll(createObjects(entityNode, doMock));
+                }
+
+                if (entityNode.size > 0) {
+                    assignWritableFields(entityNode);
+                    assignReferences(entityNode);
+                }
+
+                if (!doInsert || doMock) {
+                    continue;
+                }
+
+                if (needUpsert) {
+                    // upsert doesn't work on list of generic sObject types
+                    List<SObject> updateList = new List<SObject>();
+                    List<SObject> insertList = new List<SObject>();
+                    for (SObject obj : entityNode.objects) {
+                        if (obj.Id == null) {
+                            insertList.add(obj);
+                        } else {
+                            updateList.add(obj);
+                        }
+                    }
+                    if (updateList.size() > 0) {
+                        Database.update(updateList);
+                    }
+                    if (insertList.size() > 0) {
+                        Database.insert(insertList);
+                    }
+                } else {
+                    Database.insert(entityNode.objects);
+                }
+            }
+        }
+
+        public List<SObject> createObjects(EntityNode entityNode, Boolean doMock) {
+            List<SObject> objects = new List<SObject>();
+            if (doMock && entityNode.readonlyFields.size() > 0) {
+                objects = buildSObjectListByBatch(entityNode, 200);
+            } else {
+                Schema.SObjectType objectType = entityNode.objectType;
+                for (Integer i = 0; i < entityNode.size; ++i) {
+                    objects.add(objectType.newSObject());
+                }
+            }
+
+            if (doMock) {
+                List<Id> ids = FAKEID.generate(entityNode.objectType, objects.size());
+                for (Integer i = 0; i < objects.size(); i++) {
+                    if (objects[i].Id == null) {
+                        objects[i].Id = ids[i];
+                    }
+                }
+            }
+            return objects;
+        }
+
+        private List<SObject> buildSObjectListByBatch(EntityNode entityNode, Integer numberPerBatch) {
+            List<SObject> objects = new List<SObject>();
+            for (Integer i = 0; i * numberPerBatch < entityNode.size; i++) {
+                Integer endIndex = Math.min((i + 1) * numberPerBatch, entityNode.size);
+                String objectArrayJSON = buildSObjectArrayJSON(entityNode, i * numberPerBatch, endIndex);
+                objects.addAll((List<SObject>)JSON.deserialize(objectArrayJSON, List<SObject>.class));
+            }
+            return objects;
+        }
+
+        private String buildSObjectArrayJSON(EntityNode entityNode, Integer startIndex, Integer endIndex) {
+
+            List<Map<String, String>> fieldMaps = assignReadonlyFields(
+                entityNode.objectType, entityNode.readonlyFields, startIndex, endIndex);
+
+            StringBuilder builder = new StringBuilder();
+            builder.append('[');
+            for (Integer i = 0; i < endIndex - startIndex; ++i) {
+                if (i > 0) {
+                    builder.append(', ');
+                }
+                builder.append(buildSObjectJson(entityNode.dsr.getName(), fieldMaps[i]));
+            }
+            builder.append(']');
+            return builder.toString();
+        }
+
+        private StringBuilder buildSObjectJson(String objectName, Map<String, String> fieldMap) {
+            StringBuilder builder = new StringBuilder();
+            builder.append('{');
+            builder.append('"attributes":{"type":"'+ objectName +'"}');
+            for (String key : fieldMap.keySet()) {
+                String value = fieldMap.get(key);
+                builder.append(String.format(', "{0}": "{1}"', new List<String> { key, value}));
+            }
+            builder.append('}');
+            return builder;
+        }
+
+        public List<Map<String, String>> assignReadonlyFields(
+            SObjectType objectType, List<EntityField> entityFields, Integer startIndex, Integer endIndex) {
+
+            List<Map<String, String>> fieldMaps = new List<Map<String, String>>();
+            for (Integer i = startIndex; i < endIndex; ++i) {
+                fieldMaps.add(new Map<String, String>());
+            }
+
+            for (EntityField entityField : entityFields) {
+                if (entityField.isArithmetic) {
+                    switch on entityField.dfr.getType() {
+                        when DATE {
+                            Date init = Converter.toDate(entityField.initValue);
+                            Integer step = Converter.toInteger(entityField.stepVAlue);
+                            for (Integer i = startIndex; i < endIndex; ++i) {
+                                fieldMaps[0].put(entityField.dfr.getName(), String.valueOf(entityField.getValue(init, step, i)));
+                            }
+                        }
+                        when DATETIME {
+                            Datetime init = Converter.toDatetime(entityField.initValue);
+                            Integer step = Converter.toInteger(entityField.stepVAlue);
+                            for (Integer i = startIndex; i < endIndex; ++i) {
+                                fieldMaps[0].put(entityField.dfr.getName(), String.valueOf(entityField.getValue(init, step, i)));
+                            }
+                        }
+                        when TIME {
+                            Time init = Converter.toTime(entityField.initValue);
+                            Integer step = Converter.toInteger(entityField.stepVAlue);
+                            for (Integer i = startIndex; i < endIndex; ++i) {
+                                fieldMaps[0].put(entityField.dfr.getName(), String.valueOf(entityField.getValue(init, step, i)));
+                            }
+                        }
+                        when DOUBLE, INTEGER, PERCENT, CURRENCY {
+                            Decimal init = Converter.toDecimal(entityField.initValue);
+                            Decimal step = Converter.toDecimal(entityField.stepVAlue);
+                            for (Integer i = startIndex; i < endIndex; ++i) {
+                                fieldMaps[0].put(entityField.dfr.getName(), String.valueOf(entityField.getValue(init, step, i)));
+                            }
+                        }
+                    }
+                } else {
+                    Integer start = reserveIndex(objectType, entityField.field, endIndex - startIndex);
+                    for (Integer i = startIndex; i < endIndex; ++i) {
+                        Object value = entityField.getValue(i + start);
+                        fieldMaps[0].put(entityField.dfr.getName(), String.valueOf(value));
+                    }
+                }
+            }
+            return fieldMaps;
+        }
+
+        public void assignWritableFields(EntityNode entityNode) {
+            List<SObject> objects = entityNode.objects;
+            Integer size = objects.size();
+
+            for (EntityField entityField : entityNode.writableFields) {
+                if (entityField.isArithmetic) {
+                    switch on entityField.dfr.getType() {
+                        when DATE {
+                            Date init = Converter.toDate(entityField.initValue);
+                            Integer step = Converter.toInteger(entityField.stepVAlue);
+                            for (Integer i = 0; i < size; ++i) {
+                                objects[i].put(entityField.field, entityField.getValue(init, step, i));
+                            }
+                        }
+                        when DATETIME {
+                            Datetime init = Converter.toDatetime(entityField.initValue);
+                            Integer step = Converter.toInteger(entityField.stepVAlue);
+                            for (Integer i = 0; i < size; ++i) {
+                                objects[i].put(entityField.field, entityField.getValue(init, step, i));
+                            }
+                        }
+                        when TIME {
+                            Time init = Converter.toTime(entityField.initValue);
+                            Integer step = Converter.toInteger(entityField.stepVAlue);
+                            for (Integer i = 0; i < size; ++i) {
+                                objects[i].put(entityField.field, entityField.getValue(init, step, i));
+                            }
+                        }
+                        when DOUBLE, INTEGER, PERCENT, CURRENCY {
+                            Decimal init = Converter.toDecimal(entityField.initValue);
+                            Decimal step = Converter.toDecimal(entityField.stepVAlue);
+                            for (Integer i = 0; i < size; ++i) {
+                                objects[i].put(entityField.field, entityField.getValue(init, step, i));
+                            }
+                        }
+                    }
+                } else {
+                    Integer index = reserveIndex(entityNode.objectType, entityField.field, size);
+                    for (Integer i = 0; i < size; ++i) {
+                        Object value = entityField.getValue(i + index);
+                        objects[i].put(entityField.field, value);
+                    }
+                }
+            }
+        }
+
+        public Integer reserveIndex(SObjectType objectType, SObjectField field, Integer size) {
+            if(!indexes.containsKey(objectType)) {
+                indexes.put(objectType, new Map<Schema.SObjectField, Integer> {
+                    field => 0
+                });
+            } else if (!indexes.get(objectType).containsKey(field)) {
+                indexes.get(objectType).put(field, 0);
+            }
+            Integer index = indexes.get(objectType).get(field);
+            indexes.get(objectType).put(field, index + size);
+            return index;
+        }
+
+        @TestVisible
+        void assignReferences(EntityNode entityNode) {
+            if (entityNode.referenceToMap != null
+                && entityNode.referenceToMap.size() > 0
+                && entityNode.objects != null) {
+
+                List<SObject> childObjectList = entityNode.objects;
+
+                for (Schema.SObjectField referenceField : entityNode.referenceFields) {
+                    String relationshipName = referenceField.getDescribe().getRelationshipName();
+                    List<SObject> parentObjectList = entityNode.referenceToMap.get(referenceField).objects;
+
+                    // Open comment for debug purpose
+                    // System.debug(String.format('{0} -> {1}', new List<Object> { entityNode.objectType, relationshipName }));
+                    // System.debug(String.format('{0} -> {1}', new List<Object> { childObjectList.size(), parentObjectList.size() }));
+
+                    for (List<SObject> pair : DISTRIBUTOR.distribute(childObjectList, parentObjectList)) {
+                        // pair[0] = child
+                        // pair[1] = parent
+                        pair[0].put(referenceField, pair[1].Id);
+                        pair[0].putSObject(relationshipName, pair[1]);
+                    }
+                }
+            }
+        }
+    }
+
+    public class Distributor {
+
+        public List<List<SObject>> distribute(List<SObject> leftGroup, List<SObject> rightGroup) {
+            List<List<SObject>> groups = new List<List<SObject>>();
+
+            Integer l = leftGroup.size();
+            Integer r = rightGroup.size();
+            Integer s = l / r;
+            Integer remainder = Math.mod(l, r);
+
+            /*
+             * Balanced Set Distribution
+             * { i0, i1, i2, i3, i4 } => { j0, j1 }; then s = 2, reminder = 1
+             *                       ↓↓↓
+             *                     i0 - j0
+             *                     i1 - j0
+             *                     i2 - j0
+             *                     i3 - j1
+             *                     i4 - j1
+             */
+            for (Integer i = 0, j = 0; i < l; ++i) {
+                if (j < remainder) {
+                    j = i / (s + 1);
+                } else {
+                    j = (i - remainder) / s;
+                }
+                groups.add(new List<SObject>{
+                    leftGroup[i], rightGroup[j]
+                });
+            }
+            return groups;
+        }
+    }
+
+    // #endregion
+    // ************************
+
+    // ************************
     // #region Graph Definition
     // ************************
     public class EntityNodeMatrix implements Iterator<EntityNode> {
@@ -82,6 +370,42 @@ public with sharing class ATKCore {
             }
         }
 
+        public void add(EntityNodeType nodeType, EntityNode nextEntityNode, Schema.SObjectField referenceField) {
+            switch on nodeType {
+                when PREPARE {
+                    rowIndex = 0;
+                    colIndex = 0;
+                    entityNodeMatrix.add(new List<EntityNode>());
+                    entityNodeMatrix.get(rowIndex).add(nextEntityNode);
+                }
+                when MANY_TO_ONE {
+                    if (rowIndex > 0) {
+                        rowIndex -= 1;
+                        entityNodeMatrix.get(rowIndex).add(nextEntityNode);
+                        colIndex = entityNodeMatrix.get(rowIndex).size() - 1;
+                    } else {
+                        rowIndex = 0;
+                        colIndex = 0;
+                        entityNodeMatrix.add(rowIndex, new List<EntityNode>());
+                        entityNodeMatrix.get(rowIndex).add(nextEntityNode);
+                    }
+                }
+                when ONE_TO_MANY {
+                    rowIndex += 1;
+                    if (rowIndex == entityNodeMatrix.size()) {
+                        colIndex = 0;
+                        entityNodeMatrix.add(new List<EntityNode>());
+                        entityNodeMatrix.get(rowIndex).add(nextEntityNode);
+                    } else {
+                        colIndex = entityNodeMatrix.get(rowIndex).size();
+                        entityNodeMatrix.get(rowIndex).add(nextEntityNode);
+                    }
+                }
+            }
+
+            attach(nodeType, nextEntityNode, referenceField);
+        }
+
         public void add(EntityNodeType nodeType, Schema.SObjectType objectType, Schema.SObjectField referenceField) {
             Integer currRowIndex = rowIndex;
             Integer currColIndex = colIndex;
@@ -130,42 +454,6 @@ public with sharing class ATKCore {
             }
         }
 
-        public void add(EntityNodeType nodeType, EntityNode nextEntityNode, Schema.SObjectField referenceField) {
-            switch on nodeType {
-                when PREPARE {
-                    rowIndex = 0;
-                    colIndex = 0;
-                    entityNodeMatrix.add(new List<EntityNode>());
-                    entityNodeMatrix.get(rowIndex).add(nextEntityNode);
-                }
-                when MANY_TO_ONE {
-                    if (rowIndex > 0) {
-                        rowIndex -= 1;
-                        entityNodeMatrix.get(rowIndex).add(nextEntityNode);
-                        colIndex = entityNodeMatrix.get(rowIndex).size() - 1;
-                    } else {
-                        rowIndex = 0;
-                        colIndex = 0;
-                        entityNodeMatrix.add(rowIndex, new List<EntityNode>());
-                        entityNodeMatrix.get(rowIndex).add(nextEntityNode);
-                    }
-                }
-                when ONE_TO_MANY {
-                    rowIndex += 1;
-                    if (rowIndex == entityNodeMatrix.size()) {
-                        colIndex = 0;
-                        entityNodeMatrix.add(new List<EntityNode>());
-                        entityNodeMatrix.get(rowIndex).add(nextEntityNode);
-                    } else {
-                        colIndex = entityNodeMatrix.get(rowIndex).size();
-                        entityNodeMatrix.get(rowIndex).add(nextEntityNode);
-                    }
-                }
-            }
-
-            attach(nodeType, nextEntityNode, referenceField);
-        }
-
         void attach(EntityNodeType nodeType, EntityNode nextEntityNode, Schema.SObjectField referenceField) {
             entityNodeStack.add(nextEntityNode);
             entityNodeCache.add(nextEntityNode);
@@ -198,10 +486,10 @@ public with sharing class ATKCore {
         public List<Schema.SObjectField> referenceFields { get; set; }
         public List<SObject> objects { get; set; }
 
-
-        public Map<Schema.SObjectField, EntityField> fieldMap { get; set; }
-        public List<EntityField> fieldCache { get; set; }
         public EntityField currEntityField { get; set; }
+        public Map<Schema.SObjectField, EntityField> fieldMap { get; set; }
+        private List<EntityField> writableFields { get; set; }
+        private List<EntityField> readonlyFields { get; set; }
 
         public EntityNode(Schema.SObjectType objectType) {
             this.objectType = objectType;
@@ -210,7 +498,8 @@ public with sharing class ATKCore {
             this.referenceToMap = new Map<Schema.SObjectField, EntityNode>();
             this.referenceFields = new List<Schema.SObjectField>();
             this.fieldMap = new Map<Schema.SObjectField, EntityField>();
-            this.fieldCache = new List<EntityField>();
+            this.writableFields = new List<EntityField>();
+            this.readonlyFields = new List<EntityField>();
         }
 
         public EntityNode(Schema.SObjectType objectType, Integer size) {
@@ -232,7 +521,11 @@ public with sharing class ATKCore {
             } else {
                 entityField = new EntityField(field);
                 this.fieldMap.put(field, entityField);
-                this.fieldCache.add(entityField);
+                if (entityField.dfr.isCalculated()) {
+                    this.readonlyFields.add(entityField);
+                } else {
+                    this.writableFields.add(entityField);
+                }
             }
             this.currEntityField = entityField;
         }
@@ -261,7 +554,6 @@ public with sharing class ATKCore {
         // Fixed Value
         public Object fixedValue { get; set; }
         public Integer indexLength { get; set; }
-        public Boolean uniqueIndex { get; set; }
         public String indexFormat { get;
             set {
                 indexFormat = value;
@@ -282,7 +574,6 @@ public with sharing class ATKCore {
         public EntityField(Schema.SObjectField field) {
             this.field = field;
             this.dfr = this.field.getDescribe();
-            this.uniqueIndex = true;
         }
 
         Boolean isIndexed {
@@ -400,194 +691,6 @@ public with sharing class ATKCore {
     // #endregion
     // ************************
 
-    // ************************
-    // #region SObject Creation
-    // ************************
-
-    public class Generator {
-        public Map<Schema.SObjectType, Map<Schema.SObjectField, Integer>> indexes { get; set; }
-
-        {
-            indexes = new Map<Schema.SObjectType, Map<Schema.SObjectField, Integer>>();
-        }
-
-        public void generate(EntityNodeMatrix iterator, Boolean doInsert, Boolean doMock) {
-            iterator.reset();
-            while (iterator.hasNext()) {
-                EntityNode entityNode = iterator.next();
-                Boolean needUpsert = true;
-                if (entityNode.objects.size() == 0) {
-                    needUpsert = false;
-                    Schema.SObjectType objectType = entityNode.objectType;
-                    for (Integer i = 0; i < entityNode.size; ++i) {
-                        SObject obj = objectType.newSObject();
-                        entityNode.objects.add(obj);
-                    }
-                }
-
-                if (entityNode.size > 0) {
-                    assignFields(entityNode);
-                    assignReference(entityNode, doInsert);
-                }
-
-                if (doMock) {
-                    for (SObject obj : entityNode.objects) {
-                        if (obj.Id == null) {
-                            obj.Id = FAKEID.generate(entityNode.objectType);
-                        }
-                    }
-                    continue;
-                }
-
-                if (!doInsert) {
-                    continue;
-                }
-
-                if (needUpsert) {
-                    // upsert doesn't work on list of generic sObject types
-                    List<SObject> updateList = new List<SObject>();
-                    List<SObject> insertList = new List<SObject>();
-                    for (SObject obj : entityNode.objects) {
-                        if (obj.Id == null) {
-                            insertList.add(obj);
-                        } else {
-                            updateList.add(obj);
-                        }
-                    }
-                    if (updateList.size() > 0) {
-                        Database.update(updateList);
-                    }
-                    if (insertList.size() > 0) {
-                        Database.insert(insertList);
-                    }
-                } else {
-                    Database.insert(entityNode.objects);
-                }
-            }
-        }
-
-        public void assignFields(EntityNode entityNode) {
-            List<SObject> objects = entityNode.objects;
-            Integer size = objects.size();
-
-            for (EntityField entityField : entityNode.fieldCache) {
-                if (entityField.isArithmetic) {
-                    switch on entityField.dfr.getType() {
-                        when DATE {
-                            Date init = Converter.toDate(entityField.initValue);
-                            Integer step = Converter.toInteger(entityField.stepVAlue);
-                            for (Integer i = 0; i < size; ++i) {
-                                objects[i].put(entityField.field, entityField.getValue(init, step, i));
-                            }
-                        }
-                        when DATETIME {
-                            Datetime init = Converter.toDatetime(entityField.initValue);
-                            Integer step = Converter.toInteger(entityField.stepVAlue);
-                            for (Integer i = 0; i < size; ++i) {
-                                objects[i].put(entityField.field, entityField.getValue(init, step, i));
-                            }
-                        }
-                        when TIME {
-                            Time init = Converter.toTime(entityField.initValue);
-                            Integer step = Converter.toInteger(entityField.stepVAlue);
-                            for (Integer i = 0; i < size; ++i) {
-                                objects[i].put(entityField.field, entityField.getValue(init, step, i));
-                            }
-                        }
-                        when DOUBLE, INTEGER, PERCENT, CURRENCY {
-                            Decimal init = Converter.toDecimal(entityField.initValue);
-                            Decimal step = Converter.toDecimal(entityField.stepVAlue);
-                            for (Integer i = 0; i < size; ++i) {
-                                objects[i].put(entityField.field, entityField.getValue(init, step, i));
-                            }
-                        }
-                    }
-                } else {
-                    Integer index = 0;
-                    if (entityField.uniqueIndex) {
-                        if(!indexes.containsKey(entityNode.objectType)) {
-                            indexes.put(entityNode.objectType, new Map<Schema.SObjectField, Integer> {
-                                entityField.field => 0
-                            });
-                        } else if (!indexes.get(entityNode.objectType).containsKey(entityField.field)) {
-                            indexes.get(entityNode.objectType).put(entityField.field, 0);
-                        }
-                        index = indexes.get(entityNode.objectType).get(entityField.field);
-                        indexes.get(entityNode.objectType).put(entityField.field, index + size);
-                    }
-
-                    for (Integer i = 0; i < size; ++i) {
-                        Object value = entityField.getValue(i + index);
-                        objects[i].put(entityField.field, value);
-                    }
-                }
-            }
-        }
-
-        @TestVisible
-        void assignReference(EntityNode entityNode, Boolean doInsert) {
-            if (entityNode.referenceToMap != null
-                && entityNode.referenceToMap.size() > 0
-                && entityNode.objects != null) {
-
-                List<SObject> childObjectList = entityNode.objects;
-
-                for (Schema.SObjectField referenceField : entityNode.referenceFields) {
-                    String relationshipName = referenceField.getDescribe().getRelationshipName();
-                    List<SObject> parentObjectList = entityNode.referenceToMap.get(referenceField).objects;
-
-                    // Open comment for debug purpose
-                    // System.debug(String.format('{0} -> {1}', new List<Object> { entityNode.objectType, relationshipName }));
-                    // System.debug(String.format('{0} -> {1}', new List<Object> { childObjectList.size(), parentObjectList.size() }));
-
-                    for (List<SObject> pair : DISTRIBUTOR.distribute(childObjectList, parentObjectList)) {
-                        // pair[0] = child
-                        // pair[1] = parent
-                        pair[0].put(referenceField, pair[1].Id);
-                        pair[0].putSObject(relationshipName, pair[1]);
-                    }
-                }
-            }
-        }
-    }
-
-    public class Distributor {
-
-        public List<List<SObject>> distribute(List<SObject> leftGroup, List<SObject> rightGroup) {
-            List<List<SObject>> groups = new List<List<SObject>>();
-
-            Integer l = leftGroup.size();
-            Integer r = rightGroup.size();
-            Integer s = l / r;
-            Integer remainder = Math.mod(l, r);
-
-            /*
-             * Balanced Set Distribution
-             * { i0, i1, i2, i3, i4 } => { j0, j1 }; then s = 2, reminder = 1
-             *                       ↓↓↓
-             *                     i0 - j0
-             *                     i1 - j0
-             *                     i2 - j0
-             *                     i3 - j1
-             *                     i4 - j1
-             */
-            for (Integer i = 0, j = 0; i < l; ++i) {
-                if (j < remainder) {
-                    j = i / (s + 1);
-                } else {
-                    j = (i - remainder) / s;
-                }
-                groups.add(new List<SObject>{
-                    leftGroup[i], rightGroup[j]
-                });
-            }
-            return groups;
-        }
-    }
-
-    // #endregion
-    // ************************
-
     // ***********************
     // #region Utility Classes
     // ***********************
@@ -612,6 +715,21 @@ public with sharing class ATKCore {
             return objectType.getDescribe().getKeyPrefix()
                 + '000zzzz' // start from a large Id to avoid confliction during unit test.
                 + String.valueOf(idx.i).leftPad(5, '0');
+        }
+
+        public List<String> generate(Schema.SObjectType objectType, Integer size) {
+            List<String> ids = new List<String>();
+            if (!objectIdIndexes.containsKey(objectType)) {
+                objectIdIndexes.put(objectType, new Indexer());
+            }
+
+            Indexer idx = objectIdIndexes.get(objectType);
+            // start from a large Id to avoid confliction during unit test.
+            String prefix = objectType.getDescribe().getKeyPrefix() + '000zzzz';
+            for (Integer i = 0; i < size; i++) {
+                ids.add(prefix + String.valueOf(++idx.i).leftPad(5, '0'));
+            }
+            return ids;
         }
     }
 
@@ -847,43 +965,12 @@ public with sharing class ATKCore {
     }
 
     public class RecordTypes {
-        @TestVisible
-        Map<String, Map<String, Id>> recordTypeIdByName {
-            get {
-                if (recordTypeIdByName == null) {
-                    recordTypeIdByName = new Map<String, Map<String, Id>>();
-                    for (RecordType recordType : [SELECT
-                            Id,
-                            DeveloperName,
-                            NamespacePrefix,
-                            Name,
-                            SObjectType
-                        FROM RecordType]) {
-                        if (!recordTypeIdByName.containsKey(recordType.SObjectType.toUpperCase())) {
-                            recordTypeIdByName.put(recordType.SObjectType.toUpperCase(), new Map<String, Id> {
-                                recordType.DeveloperName.toUpperCase() => recordType.Id,
-                                recordType.Name.toUpperCase() => recordType.Id
-                            });
-                        } else {
-                            recordTypeIdByName.get(recordType.SObjectType.toUpperCase())
-                                .put(recordType.DeveloperName.toUpperCase(), recordType.Id);
-                            recordTypeIdByName.get(recordType.SObjectType.toUpperCase())
-                                .put(recordType.Name.toUpperCase(), recordType.Id);
-                        }
-                    }
-                }
-                return recordTypeIdByName;
+        public Id getId(DescribeSObjectResult dsr, String developerName) {
+            RecordTypeInfo recordTypeInfo = dsr.getRecordTypeInfosByDeveloperName().get(developerName);
+            if (recordTypeInfo != null) {
+                return recordTypeInfo.getRecordTypeId();
             }
-            set;
-        }
-
-        public Id getId(SObjectType objectType, String name) {
-            Map<String, Id> recordTypeIds = recordTypeIdByName.get(String.valueOf(objectType).toUpperCase());
-            if (recordTypeIds != null) {
-                return recordTypeIds.get(name.toUpperCase());
-            } else {
-                return null;
-            }
+            return null;
         }
     }
 

--- a/apex-test-kit/main/classes/ATKCore.cls
+++ b/apex-test-kit/main/classes/ATKCore.cls
@@ -48,6 +48,13 @@ public with sharing class ATKCore {
                     objects.addAll(createObjects(entityNode, doMock));
                 }
 
+                if (entityNode.size > 0) {
+                    assignWritableFields(entityNode);
+                    assignReferences(entityNode);
+                }
+
+                // Ids should be assigned after reference assignments, because once Ids are
+                // assigned some relationships are no longer updatable.
                 if (doMock) {
                     List<Id> ids = FAKEID.generate(entityNode.objectType, objects.size());
                     for (Integer i = 0; i < objects.size(); i++) {
@@ -55,11 +62,6 @@ public with sharing class ATKCore {
                             objects[i].Id = ids[i];
                         }
                     }
-                }
-
-                if (entityNode.size > 0) {
-                    assignWritableFields(entityNode);
-                    assignReferences(entityNode);
                 }
 
                 if (!doInsert || doMock) {
@@ -271,9 +273,6 @@ public with sharing class ATKCore {
                     for (List<SObject> pair : DISTRIBUTOR.distribute(childObjectList, parentObjectList)) {
                         // pair[0] = child
                         // pair[1] = parent
-                        System.debug(referenceField.getDescribe().isCreateable());
-                        System.debug(referenceField.getDescribe().isUpdateable());
-                        System.debug(pair[1].Id);
                         pair[0].put(referenceField, pair[1].Id);
                         pair[0].putSObject(relationshipName, pair[1]);
                     }

--- a/apex-test-kit/main/classes/ATKCore.cls-meta.xml
+++ b/apex-test-kit/main/classes/ATKCore.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>49.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/apex-test-kit/main/classes/ATKCoreTest.cls
+++ b/apex-test-kit/main/classes/ATKCoreTest.cls
@@ -347,7 +347,7 @@ public with sharing class ATKCoreTest {
             }
             entity.addField(Account.Name);
             entity.currEntityField.fixedValue = 'Name';
-            generator.assignFields(entity);
+            generator.assignWritableFields(entity);
         }
 
         {
@@ -359,7 +359,7 @@ public with sharing class ATKCoreTest {
             entity.currEntityField.arithmetic = ATKCore.EntityFieldArithmetic.ADD_DAYS;
             entity.currEntityField.initValue = Date.newInstance(2020, 1, 1);
             entity.currEntityField.stepValue = 1;
-            generator.assignFields(entity);
+            generator.assignWritableFields(entity);
         }
 
         {
@@ -371,7 +371,7 @@ public with sharing class ATKCoreTest {
             entity.currEntityField.arithmetic = ATKCore.EntityFieldArithmetic.ADD;
             entity.currEntityField.initValue = 0.1;
             entity.currEntityField.stepValue = 0.1;
-            generator.assignFields(entity);
+            generator.assignWritableFields(entity);
         }
 
         {
@@ -385,7 +385,7 @@ public with sharing class ATKCoreTest {
             entity.currEntityField.initValue = DateTime.newInstance(2020, 1, 1, 0, 0, 0);
             entity.currEntityField.stepValue = 1;
             entity.addField(Event.ActivityDateTime);
-            generator.assignFields(entity);
+            generator.assignWritableFields(entity);
         }
     }
 
@@ -429,14 +429,14 @@ public with sharing class ATKCoreTest {
     }
 
     @IsTest
-    static void test_Generator_Generate_doMock() {
+    static void test_Generator_Generate_doMock_Empty() {
         ATKCore.Generator generator = new ATKCore.Generator();
         {
             ATKCore.EntityNodeMatrix matrix = new ATKCore.EntityNodeMatrix();
             matrix.add(ATKCore.EntityNodeType.PREPARE,
                 new ATKCore.EntityNode(Account.SObjectType,
-                    new List<Account> {new Account(), new Account(), new Account()})
-                , null);
+                    new List<Account> {new Account(), new Account(), new Account()}),
+                null);
             matrix.add(ATKCore.EntityNodeType.ONE_TO_MANY,
                 new ATKCore.EntityNode(Contact.SObjectType, 3),
                 Contact.AccountId);
@@ -448,6 +448,49 @@ public with sharing class ATKCoreTest {
                 System.assert(node.objects.size() > 0);
                 for (SObject obj : node.objects) {
                     System.assertNotEquals(null, obj.Id);
+                }
+            }
+        }
+    }
+
+    @IsTest
+    static void test_Generator_Generate_doMock_SystemField() {
+        ATKCore.Generator generator = new ATKCore.Generator();
+        Id fakeUserId = ATKCore.FakeId.get(User.SObjectType, 1);
+        {
+            ATKCore.EntityNodeMatrix matrix = new ATKCore.EntityNodeMatrix();
+            matrix.add(ATKCore.EntityNodeType.PREPARE,
+                new ATKCore.EntityNode(Account.SObjectType, 3),
+                null);
+            matrix.currEntityNode.addField(Account.CreatedDate);
+            matrix.currEntityNode.currEntityField.fixedValue = Datetime.newInstance(2020, 1, 1);
+            matrix.currEntityNode.addField(Account.CreatedById);
+            matrix.currEntityNode.currEntityField.fixedValue = fakeUserId;
+            matrix.add(ATKCore.EntityNodeType.ONE_TO_MANY,
+                new ATKCore.EntityNode(Contact.SObjectType, 3),
+                Contact.AccountId);
+            matrix.currEntityNode.addField(Contact.CreatedDate);
+            matrix.currEntityNode.currEntityField.fixedValue = Datetime.newInstance(2020, 1, 1);
+            matrix.currEntityNode.addField(Contact.CreatedById);
+            matrix.currEntityNode.currEntityField.fixedValue = fakeUserId;
+
+            generator.generate(matrix, false, true);
+            System.assertEquals(2, matrix.entityNodeCache.size());
+
+            Datetime expectedDatetime = Datetime.newInstance(2020, 1, 1);
+            for (ATKCore.EntityNode node : matrix.entityNodeCache) {
+                System.assert(node.objects.size() > 0);
+                for (SObject obj : node.objects) {
+                    if (node.objectType == Account.SObjectType) {
+                        Account acc = (Account)obj;
+                        System.assertEquals(expectedDatetime, acc.CreatedDate);
+                        System.assertEquals(fakeUserId, acc.CreatedById);
+                    }
+                    if (node.objectType == Contact.SObjectType) {
+                        Contact con = (Contact)obj;
+                        System.assertEquals(expectedDatetime, con.CreatedDate);
+                        System.assertEquals(fakeUserId, con.CreatedById);
+                    }
                 }
             }
         }
@@ -602,6 +645,14 @@ public with sharing class ATKCoreTest {
             Id permissionSetId = ATKCore.PERMISSION_SETS.getId('==Fake Permission Set==');
             System.assertEquals(null, permissionSetId);
         }
+
+        {
+            List<Id> permissionSetIds = ATKCore.PERMISSION_SETS.getIds(new List<String> {
+                '==Fake Permission Set 1==',
+                '==Fake Permission Set 2==',
+                '==Fake Permission Set 3=='});
+            System.assertEquals(0, permissionSetIds.size());
+        }
     }
 
     @IsTest
@@ -633,4 +684,13 @@ public with sharing class ATKCoreTest {
             System.assertEquals(null, recordTypeId);
         }
     }
+
+    @IsTest
+    static void test_Util_FakeId() {
+        system.assert(ATKCore.FAKEID.get(Account.SObjectType, 1).endsWith('00001'));
+        system.assert(ATKCore.FAKEID.get(Account.SObjectType, 1).endsWith('00001'));
+        system.assert(ATKCore.FAKEID.get(Account.SObjectType, 2).endsWith('00002'));
+        system.assert(ATKCore.FAKEID.get(Contact.SObjectType, 2).endsWith('00002'));
+    }
+
 }

--- a/apex-test-kit/main/classes/ATKCoreTest.cls
+++ b/apex-test-kit/main/classes/ATKCoreTest.cls
@@ -398,7 +398,7 @@ public with sharing class ATKCoreTest {
                 new List<Account> {new Account(), new Account(), new Account()}), null);
             matrix.add(ATKCore.EntityNodeType.ONE_TO_MANY, new ATKCore.EntityNode(Contact.SObjectType,
                 new List<Contact> {new Contact(), new Contact(), new Contact()}), Contact.AccountId);
-            generator.assignReference(matrix.currEntityNode, true);
+            generator.assignReferences(matrix.currEntityNode);
         }
     }
 
@@ -433,9 +433,14 @@ public with sharing class ATKCoreTest {
         ATKCore.Generator generator = new ATKCore.Generator();
         {
             ATKCore.EntityNodeMatrix matrix = new ATKCore.EntityNodeMatrix();
-            matrix.add(ATKCore.EntityNodeType.PREPARE, new ATKCore.EntityNode(Account.SObjectType,
-                new List<Account> {new Account(), new Account(), new Account()}), null);
-            matrix.add(ATKCore.EntityNodeType.ONE_TO_MANY, new ATKCore.EntityNode(Contact.SObjectType, 3), Contact.AccountId);
+            matrix.add(ATKCore.EntityNodeType.PREPARE,
+                new ATKCore.EntityNode(Account.SObjectType,
+                    new List<Account> {new Account(), new Account(), new Account()})
+                , null);
+            matrix.add(ATKCore.EntityNodeType.ONE_TO_MANY,
+                new ATKCore.EntityNode(Contact.SObjectType, 3),
+                Contact.AccountId);
+
             generator.generate(matrix, false, true);
 
             System.assertEquals(2, matrix.entityNodeCache.size());
@@ -606,27 +611,25 @@ public with sharing class ATKCoreTest {
             System.assertEquals(null, profileId);
         }
 
-        {
-            try {
-                Profile profile = [
-                    SELECT Id, Name
-                    FROM Profile
-                    WHERE Name = 'System Administrator'
-                    WITH SECURITY_ENFORCED];
-                if (profile != null) {
-                    Id profileId = ATKCore.PROFILES.getId('System Administrator');
-                    System.assertEquals(profile.Id, profileId);
-                }
-            } catch(System.QueryException ex) {
-
+        try {
+            Profile profile = [
+                SELECT Id, Name
+                FROM Profile
+                WHERE Name = 'System Administrator'
+                WITH SECURITY_ENFORCED];
+            if (profile != null) {
+                Id profileId = ATKCore.PROFILES.getId('System Administrator');
+                System.assertEquals(profile.Id, profileId);
             }
+        } catch(System.QueryException ex) {
+
         }
     }
 
     @IsTest
     static void test_Util_RecordTypes() {
         {
-            Id recordTypeId = ATKCore.RECORD_TYPES.getId(Account.SObjectType, '==Fake Record Type==');
+            Id recordTypeId = ATKCore.RECORD_TYPES.getId(Account.SObjectType.getDescribe(), '==Fake Record Type==');
             System.assertEquals(null, recordTypeId);
         }
     }

--- a/apex-test-kit/main/classes/ATKCoreTest.cls-meta.xml
+++ b/apex-test-kit/main/classes/ATKCoreTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>49.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/apex-test-kit/main/classes/ATKTest.cls
+++ b/apex-test-kit/main/classes/ATKTest.cls
@@ -51,14 +51,14 @@ public with sharing class ATKTest {
     }
 
     @IsTest
-    static void test_OneToMany_mock() {
+    static void test_OneToMany_Mock() {
         ATK.SaveResult result = ATK.prepare(Account.SObjectType, 10)
             .withChildren(Case.SObjectType, Case.AccountId, 40)
             .also()
             .withChildren(Contact.SObjectType, Contact.AccountId, 20)
                 // in order to test this method
                 .withChildren(Case.SObjectType, Case.ContactId)
-            .save(false);
+            .mock();
 
         for (Integer i = 0; i < 10; i++) {
             Account acc = (Account)result.get(Account.SObjectType)[i];
@@ -352,4 +352,24 @@ public with sharing class ATKTest {
         }
     }
 
+    @IsTest
+    static void test_Mock_SystemField() {
+        ATKCore.batchSize = 3;
+
+        Id fakeUserId = ATKCore.FakeId.get(User.SObjectType, 1);
+        ATK.SaveResult result = ATK.prepare(Account.SObjectType, 9)
+            .field(Account.CreatedById).repeat(fakeUserId)
+            .field(Account.CreatedDate).repeat(Datetime.newInstance(2020, 1, 1))
+            .field(Account.LastModifiedById).repeat(fakeUserId)
+            .field(Account.LastModifiedDate).addDays(Datetime.newInstance(2020, 1, 1), 1)
+            .mock();
+
+        List<SObject> accounts = result.get(Account.SObjectType);
+        System.assertEquals(9, accounts.size());
+        for (SObject obj : accounts) {
+            Account acc = (Account)obj;
+            System.assertEquals(fakeUserId, acc.CreatedById);
+            System.assertEquals(Datetime.newInstance(2020, 1, 1), acc.CreatedDate);
+        }
+    }
 }

--- a/apex-test-kit/main/classes/ATKTest.cls-meta.xml
+++ b/apex-test-kit/main/classes/ATKTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>49.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/scripts/apex/benchmark.apex
+++ b/scripts/apex/benchmark.apex
@@ -1,0 +1,38 @@
+Savepoint sp = Database.setSavepoint();
+Datetime startTime = Datetime.now();
+List<Account> accounts = new List<Account>();
+for (Integer i = 0; i < 1000; i++) {
+    accounts.add(new Account(
+        Name = 'Name-' + i
+    ));
+}
+insert accounts;
+Datetime endTime = Datetime.now();
+System.debug(endTime.getTime() - startTime.getTime());
+Database.rollback(sp);
+
+
+Savepoint sp = Database.setSavepoint();
+Datetime startTime = Datetime.now();
+ATK.prepare(Account.SObjectType, 1000)
+    .field(Account.Name).index('Name-{0000}')
+    .field(Account.Phone).index('+86 186 7777 {0000}')
+    .field(Account.Description).repeat('Description...')
+    .save();
+Datetime endTime = Datetime.now();
+System.debug(endTime.getTime() - startTime.getTime());
+Database.rollback(sp);
+
+
+Savepoint sp = Database.setSavepoint();
+Datetime startTime = Datetime.now();
+ATK.prepare(Account.SObjectType, 1000)
+    .field(Account.Name).index('Name-{0000}')
+    .field(Account.CreatedById).repeat(ATKCore.FAKEID.get(User.SObjectType, 1))
+    .field(Account.CreatedDate).repeat(Datetime.newInstance(2020, 1, 1))
+    .field(Account.LastModifiedById).repeat(ATKCore.FAKEID.get(User.SObjectType, 1))
+    .field(Account.LastModifiedDate).repeat(Datetime.newInstance(2020, 1, 1))
+    .mock();
+Datetime endTime = Datetime.now();
+System.debug(endTime.getTime() - startTime.getTime());
+Database.rollback(sp);

--- a/scripts/sfdx.shell
+++ b/scripts/sfdx.shell
@@ -1,4 +1,0 @@
-sfdx force:package:version:create -p ApexTestKit -x --wait 10
-sfdx force:package:version:list
-sfdx force:package:version:promote -p "ApexTestKit@3.0.1-1"
-sfdx force:package:version:report -p ApexTestKit@3.0.1-1

--- a/scripts/shell/sfdx.sh
+++ b/scripts/shell/sfdx.sh
@@ -1,0 +1,4 @@
+sfdx force:package:version:create -p ApexTestKit -x -c --wait 10
+sfdx force:package:version:list
+sfdx force:package:version:promote -p 04t2v000007GQuwAAG
+sfdx force:package:version:report -p 04t2v000007GQuwAAG

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -3,8 +3,8 @@
         {
             "path": "apex-test-kit",
             "package": "ApexTestKit",
-            "versionName": "ver 3.2.1",
-            "versionNumber": "3.2.1.NEXT",
+            "versionName": "ver 3.3.1",
+            "versionNumber": "3.3.1.NEXT",
             "default": true
         }
     ],
@@ -18,6 +18,7 @@
         "ApexTestKit@3.0.2-1": "04t2v000007X3LqAAK",
         "ApexTestKit@3.1.0-1": "04t2v000007X3Q7AAK",
         "ApexTestKit@3.2.0-1": "04t2v000007X4XzAAK",
-        "ApexTestKit@3.2.1-2": "04t2v000007X4qeAAC"
+        "ApexTestKit@3.2.1-2": "04t2v000007X4qeAAC",
+        "ApexTestKit@3.3.1-1": "04t2v000007GQuwAAG"
     }
 }


### PR DESCRIPTION
**Lookup Field Keywords** has some **breaking changes**:

- `recordType()` will only support developer name as param, and become *case sensitive*.

**Command API**:

- `mock()` now supports assigning read-only fields, such as *formula fields*, *rollup summary fields*, and *system fields*. For example `.field(Account.CreatedDate).repeat(Datetime.newInstance(2020, 1, 1))`.
- Fix:  Fake Id assignments of sObjects during `mock()`  blocking some relationships to be updated.

**Performance** adds **benchmark** to give a feel how fast it is to use `mock()` compared with `save()`.